### PR TITLE
CCP-1586: Added retry logic for failed bolt script injection

### DIFF
--- a/extension-config.json
+++ b/extension-config.json
@@ -69,6 +69,16 @@
         "type": "string",
         "label": "Merchant's shopping cart provider"
       }
+    },
+    "maximumBoltInjectionRetries": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": "3",
+      "params": {
+        "required": true,
+        "type": "number",
+        "label": "Maximum number of retries for Bolt Script Injections"
+      }
     }
   }
 }

--- a/extension-config.json
+++ b/extension-config.json
@@ -69,16 +69,6 @@
         "type": "string",
         "label": "Merchant's shopping cart provider"
       }
-    },
-    "maximumBoltInjectionRetries": {
-      "type": "admin",
-      "destination": "frontend",
-      "default": "3",
-      "params": {
-        "required": true,
-        "type": "number",
-        "label": "Maximum number of retries for Bolt Script Injections"
-      }
     }
   }
 }

--- a/frontend/portals/CartCheckoutButton/CartCheckoutButton.jsx
+++ b/frontend/portals/CartCheckoutButton/CartCheckoutButton.jsx
@@ -4,9 +4,6 @@ import PropTypes from 'prop-types';
 import { logger } from '@shopgate/pwa-core';
 import injectBoltConnect from '../../helpers/injectBoltConnect';
 import CheckoutButton from '../../components/CheckoutButton';
-import getConfig from '../../helpers/getConfig';
-
-const { maximumBoltInjectionRetries } = getConfig();
 /**
  * @returns {JSX}
  */
@@ -23,25 +20,8 @@ const CartCheckoutButton = ({
   }
 
   useEffect(() => {
-    /**
-     * Retry promise to handle maximum number of retries and provide error log
-     * @returns {Function}
-     */
-    const retry = () => new Promise((resolve, reject) => {
-      let retries = 0;
-      injectBoltConnect()
-        .then(resolve)
-        .catch(() => {
-          retries += 1;
-          if (retries === maximumBoltInjectionRetries) {
-            reject(new Error('Maximum retry limit reached'));
-            return;
-          }
-          retry().then(resolve);
-        });
-    });
     // If script is already there and ready, it will simply resolve.
-    retry()
+    injectBoltConnect()
       .then(() => {
         const cart = {
           orderToken,

--- a/frontend/portals/CartCheckoutButton/CartCheckoutButton.jsx
+++ b/frontend/portals/CartCheckoutButton/CartCheckoutButton.jsx
@@ -1,8 +1,12 @@
 /* globals BoltCheckout */
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { logger } from '@shopgate/pwa-core';
 import injectBoltConnect from '../../helpers/injectBoltConnect';
 import CheckoutButton from '../../components/CheckoutButton';
+import getConfig from '../../helpers/getConfig';
+
+const { maximumBoltInjectionRetries } = getConfig();
 /**
  * @returns {JSX}
  */
@@ -19,8 +23,25 @@ const CartCheckoutButton = ({
   }
 
   useEffect(() => {
+    /**
+     * Retry promise to handle maximum number of retries and provide error log
+     * @returns {Function}
+     */
+    const retry = () => new Promise((resolve, reject) => {
+      let retries = 0;
+      injectBoltConnect()
+        .then(resolve)
+        .catch(() => {
+          retries += 1;
+          if (retries === maximumBoltInjectionRetries) {
+            reject(new Error('Maximum retry limit reached'));
+            return;
+          }
+          retry().then(resolve);
+        });
+    });
     // If script is already there and ready, it will simply resolve.
-    injectBoltConnect()
+    retry()
       .then(() => {
         const cart = {
           orderToken,
@@ -42,7 +63,7 @@ const CartCheckoutButton = ({
         BoltCheckout.configure(cart, hints, callbacks);
       })
       .catch((error) => {
-        // How to handle error here? Retry?
+        logger.error(error);
       });
   }, [orderToken, prefill]);
 


### PR DESCRIPTION
## Description

Added a config to set maximum number of retries on checkout page. Error will be thrown if limit reached. 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md