### PR TITLE
CCP-1966: added willUpdate property of cartToken redux state to be us…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Disabling bolt checkout during cart item update
 
 ## [1.1.3] - 2020-01-22
 ### Fixed

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.3",
+  "version": "1.1.4-rc.1",
   "id": "@shopgate-project/bolt-checkout",
   "components": [
     {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate-project/bolt-checkout",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "",
   "license": "Apache-2.0",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate-project/bolt-checkout",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Extension to enable Bolt Checkout",
   "license": "Apache-2.0",
   "scripts": {

--- a/frontend/reducers/boltCartToken.js
+++ b/frontend/reducers/boltCartToken.js
@@ -1,3 +1,4 @@
+import { UPDATE_PRODUCTS_IN_CART } from '@shopgate/engage/cart';
 import {
   RECEIVE_BOLT_CART_TOKEN,
   REQUEST_BOLT_CART_TOKEN,
@@ -14,24 +15,34 @@ const boltTokenReducer = (
   state = {
     cartToken: null,
     isFetching: false,
+    willUpdate: false,
   },
   action
 ) => {
   switch (action.type) {
+    case UPDATE_PRODUCTS_IN_CART: {
+      return {
+        ...state,
+        willUpdate: true,
+      };
+    }
     case REQUEST_BOLT_CART_TOKEN:
       return {
         ...state,
         isFetching: true,
+        willUpdate: false,
       };
     case RECEIVE_BOLT_CART_TOKEN:
       return {
         ...action.boltCartToken,
         isFetching: false,
+        willUpdate: false,
       };
     case ERROR_BOLT_CART_TOKEN:
       return {
         ...state,
         isFetching: false,
+        willUpdate: false,
       };
     default:
       return state;

--- a/frontend/reducers/boltCartToken.js
+++ b/frontend/reducers/boltCartToken.js
@@ -1,4 +1,9 @@
-import { UPDATE_PRODUCTS_IN_CART } from '@shopgate/engage/cart';
+import {
+  UPDATE_PRODUCTS_IN_CART,
+  DELETE_PRODUCTS_FROM_CART,
+  ADD_COUPONS_TO_CART,
+  DELETE_COUPONS_FROM_CART,
+} from '@shopgate/engage/cart';
 import {
   RECEIVE_BOLT_CART_TOKEN,
   REQUEST_BOLT_CART_TOKEN,
@@ -20,12 +25,14 @@ const boltTokenReducer = (
   action
 ) => {
   switch (action.type) {
-    case UPDATE_PRODUCTS_IN_CART: {
+    case UPDATE_PRODUCTS_IN_CART:
+    case DELETE_PRODUCTS_FROM_CART:
+    case ADD_COUPONS_TO_CART:
+    case DELETE_COUPONS_FROM_CART:
       return {
         ...state,
         willUpdate: true,
       };
-    }
     case REQUEST_BOLT_CART_TOKEN:
       return {
         ...state,

--- a/frontend/selectors/index.js
+++ b/frontend/selectors/index.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import { getUserData } from '@shopgate/pwa-common/selectors/user';
-import { getIsFetching } from '@shopgate/engage/cart';
+import { getIsFetching, getOrderableStatus } from '@shopgate/engage/cart';
 import { REDUX_NAMESPACE_BOLT_CART_TOKEN } from '../constants';
 
 /**
@@ -73,8 +73,17 @@ const isTokenFetching = createSelector(
   tokenState => tokenState.isFetching
 );
 
+const willTokenUpdate = createSelector(
+  getBoltCartTokenState,
+  tokenState => tokenState.willUpdate
+);
+
 export const getIsCartBusy = createSelector(
   getIsFetching,
+  getOrderableStatus,
   isTokenFetching,
-  (cartFetching, tokenFetching) => cartFetching || tokenFetching
+  willTokenUpdate,
+  (cartFetching, cartOrderable, tokenFetching, tokenWillUpdate) => (
+    cartFetching || !cartOrderable || tokenFetching || tokenWillUpdate
+  )
 );


### PR DESCRIPTION
…ed to disable bolt checkout button during cart update

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md

I tried several approaches to fixing this issue. I found this to be the best because there is a small period of time between the cart update completing and the beginning of the bolt cart token fetching process. During this period of time the checkout button would become active with the old token if only the cart loading is considered to determine if the bolt checkout button should be disabled.   